### PR TITLE
hudd: protect nodes with a mutex

### DIFF
--- a/hudd.go
+++ b/hudd.go
@@ -2,6 +2,7 @@
 //
 // MIT License
 
+//go:build !buddy
 // +build !buddy
 
 package rudd
@@ -9,6 +10,7 @@ package rudd
 import (
 	"fmt"
 	"log"
+	"sync"
 	"sync/atomic"
 	"unsafe"
 )
@@ -19,6 +21,7 @@ import (
 // space but a benefit is that we can easily migrate to a concurrency-safe
 // hashmap if we want to test concurrent data structures.
 type tables struct {
+	sync.RWMutex
 	nodes         []huddnode             // List of all the BDD nodes. Constants are always kept at index 0 and 1
 	unique        map[[huddsize]byte]int // Unicity table, used to associate each triplet to a single node
 	freenum       int                    // Number of free nodes
@@ -41,14 +44,20 @@ type huddnode struct {
 }
 
 func (b *tables) ismarked(n int) bool {
+	b.RLock()
+	defer b.RUnlock()
 	return (b.nodes[n].refcou & 0x200000) != 0
 }
 
 func (b *tables) marknode(n int) {
+	b.RLock()
+	defer b.RUnlock()
 	b.nodes[n].refcou |= 0x200000
 }
 
 func (b *tables) unmarknode(n int) {
+	b.RLock()
+	defer b.RUnlock()
 	b.nodes[n].refcou &= 0x1FFFFF
 }
 
@@ -133,6 +142,8 @@ func New(varnum int, options ...func(*configs)) (*BDD, error) {
 	}
 	impl.gcstat.history = []gcpoint{}
 	impl.nodefinalizer = func(n *int) {
+		b.Lock()
+		defer b.Unlock()
 		if _DEBUG {
 			atomic.AddUint64(&(impl.gcstat.calledfinalizers), 1)
 			if _LOGLEVEL > 2 {
@@ -189,6 +200,8 @@ func (b *tables) nodehash(level int32, low, high int) (int, bool) {
 // unused slot, except when freenum is 0, in which case it is also 0.
 
 func (b *tables) setnode(level int32, low int, high int, count int32) int {
+	b.Lock()
+	defer b.Unlock()
 	b.huddhash(level, low, high)
 	b.freenum--
 	b.unique[b.hbuff] = b.freepos
@@ -204,22 +217,32 @@ func (b *tables) delnode(hn huddnode) {
 }
 
 func (b *tables) size() int {
+	b.RLock()
+	defer b.RUnlock()
 	return len(b.nodes)
 }
 
 func (b *tables) level(n int) int32 {
+	b.RLock()
+	defer b.RUnlock()
 	return b.nodes[n].level
 }
 
 func (b *tables) low(n int) int {
+	b.RLock()
+	defer b.RUnlock()
 	return b.nodes[n].low
 }
 
 func (b *tables) high(n int) int {
+	b.RLock()
+	defer b.RUnlock()
 	return b.nodes[n].high
 }
 
 func (b *tables) allnodesfrom(f func(id, level, low, high int) error, n []Node) error {
+	b.RLock()
+	defer b.RUnlock()
 	for _, v := range n {
 		b.markrec(*v)
 	}
@@ -244,6 +267,8 @@ func (b *tables) allnodesfrom(f func(id, level, low, high int) error, n []Node) 
 }
 
 func (b *tables) allnodes(f func(id, level, low, high int) error) error {
+	b.RLock()
+	defer b.RUnlock()
 	// if err := f(0, int(b.nodes[0].level), 0, 0); err != nil {
 	// 	return err
 	// }
@@ -262,6 +287,8 @@ func (b *tables) allnodes(f func(id, level, low, high int) error) error {
 
 // stats returns information about the implementation
 func (b *tables) stats() string {
+	b.RLock()
+	defer b.RUnlock()
 	res := "Impl.:      Hudd\n"
 	res += fmt.Sprintf("Allocated:  %d (%s)\n", len(b.nodes), humanSize(len(b.nodes), unsafe.Sizeof(huddnode{})))
 	res += fmt.Sprintf("Produced:   %d\n", b.produced)


### PR DESCRIPTION
We saw this race in CI: 

```
WARNING: DATA RACE
Read at 0x00c000212558 by goroutine 63:
  github.com/dalzilio/rudd.(*tables).ismarked()
      /home/runner/go/pkg/mod/github.com/dalzilio/rudd@v1.1.0/hudd.go:44 +0x149
  github.com/dalzilio/rudd.(*tables).allnodesfrom()
      /home/runner/go/pkg/mod/github.com/dalzilio/rudd@v1.1.0/hudd.go:235 +0x160
  github.com/dalzilio/rudd.(*BDD).Allnodes()
      /home/runner/go/pkg/mod/github.com/dalzilio/rudd@v1.1.0/operations.go:712 +0x1ac
  github.com/dalzilio/rudd.(*BDD).Print()
      /home/runner/go/pkg/mod/github.com/dalzilio/rudd@v1.1.0/stdio.go:64 +0x284
  github.com/authzed/spicedb/internal/namespace.computeCanonicalCacheKeys()
      /home/runner/work/spicedb/spicedb/internal/namespace/canonicalization.go:76 +0x3a4
  github.com/authzed/spicedb/internal/namespace.AnnotateNamespace()
      /home/runner/work/spicedb/spicedb/internal/namespace/annotate.go:11 +0x65
  github.com/authzed/spicedb/internal/testfixtures.StandardDatastoreWithSchema()
      /home/runner/work/spicedb/spicedb/internal/testfixtures/datastore.go:124 +0x359
  github.com/authzed/spicedb/internal/testfixtures.StandardDatastoreWithData()
      /home/runner/work/spicedb/spicedb/internal/testfixtures/datastore.go:136 +0x67
  github.com/authzed/spicedb/internal/datastore/test.EmptyNamespaceDeleteTest()
      /home/runner/work/spicedb/spicedb/internal/datastore/test/namespace.go:159 +0xde
  github.com/authzed/spicedb/internal/datastore/test.All.func9()
      /home/runner/work/spicedb/spicedb/internal/datastore/test/datastore.go:45 +0x48
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1486 +0x47

Previous write at 0x00c000212558 by goroutine 6:
  github.com/dalzilio/rudd.New.func1()
      /home/runner/go/pkg/mod/github.com/dalzilio/rudd@v1.1.0/hudd.go:142 +0xae
```
(https://github.com/authzed/spicedb/runs/6131744750?check_suite_focus=true for reference)

Go runs finalizers in a separate goroutine, so safely altering the refcount in the `nodes` array requires synchronizing access somehow. 

In this PR I used the mutex hammer to solve this; there is likely something more elegant we can do instead, but I figured I'd make the simple change and see what feedback you had.